### PR TITLE
fix(ci): only run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  push:
     branches: [master]
   workflow_dispatch:
 
@@ -11,7 +9,6 @@ jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     concurrency: release
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,12 +36,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          output=$(uv run semantic-release version 2>&1) || true
+          # Use --no-commit to avoid pushing to protected branch
+          # This only creates the tag and GitHub release
+          output=$(uv run semantic-release version --no-commit --no-push 2>&1) || true
           echo "$output"
           if echo "$output" | grep -q "No release will be made"; then
             echo "released=false" >> $GITHUB_OUTPUT
           elif [ -d "dist" ] && [ "$(ls -A dist)" ]; then
             echo "released=true" >> $GITHUB_OUTPUT
+            # Push only the tag, not commits
+            git push --tags
             uv run semantic-release publish
           else
             echo "released=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,14 @@ jobs:
             echo "released=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Upload dist artifacts
+        if: steps.release.outputs.released == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
   publish:
     name: Publish to PyPI
     needs: release
@@ -60,24 +68,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
         with:
-          ref: master
-          fetch-depth: 0
-
-      - name: Pull latest changes
-        run: git pull origin master
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Build package
-        run: uv build
+          name: dist
+          path: dist/
 
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,19 @@ jobs:
     concurrency: release
     permissions:
       contents: write
+      id-token: write
     outputs:
       released: ${{ steps.release.outputs.released }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -34,19 +40,14 @@ jobs:
       - name: Semantic Release
         id: release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          # Use --no-commit to avoid pushing to protected branch
-          # This only creates the tag and GitHub release
-          output=$(uv run semantic-release version --no-commit --no-push 2>&1) || true
+          output=$(uv run semantic-release version 2>&1) || true
           echo "$output"
           if echo "$output" | grep -q "No release will be made"; then
             echo "released=false" >> $GITHUB_OUTPUT
           elif [ -d "dist" ] && [ "$(ls -A dist)" ]; then
             echo "released=true" >> $GITHUB_OUTPUT
-            # Push only the tag, not commits
-            git push --tags
-            uv run semantic-release publish
           else
             echo "released=false" >> $GITHUB_OUTPUT
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,6 @@ commit_message = "chore(release): {version}"
 tag_format = "v{version}"
 major_on_zero = false
 allow_zero_version = true
-commit_version_number = false  # Don't commit version bump - works with branch protection
-no_git_verify = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["feat", "fix", "perf", "refactor", "build", "chore", "docs", "style", "test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ commit_message = "chore(release): {version}"
 tag_format = "v{version}"
 major_on_zero = false
 allow_zero_version = true
+commit_version_number = false  # Don't commit version bump - works with branch protection
+no_git_verify = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["feat", "fix", "perf", "refactor", "build", "chore", "docs", "style", "test"]


### PR DESCRIPTION
CI should only run on PRs, not on merge to master. CD handles the release.