### PR TITLE
fix: use dynamic version from package metadata

### DIFF
--- a/src/empire_core/__init__.py
+++ b/src/empire_core/__init__.py
@@ -2,6 +2,8 @@
 EmpireCore - Python library for Goodgame Empire automation.
 """
 
+from importlib.metadata import version
+
 from empire_core.client.client import EmpireClient
 from empire_core.config import EmpireConfig
 from empire_core.state.models import Alliance, Building, Castle, Player, Resources
@@ -9,7 +11,7 @@ from empire_core.state.unit_models import UNIT_IDS, Army, UnitStats
 from empire_core.state.world_models import MapObject, Movement, MovementResources
 from empire_core.utils.enums import KingdomType, MapObjectType, MovementType
 
-__version__ = "0.1.0"
+__version__ = version(__package__)
 
 __all__ = [
     "EmpireClient",

--- a/uv.lock
+++ b/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "empire-core"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Uses `importlib.metadata.version()` to get version from installed package
- Removes hardcoded `__version__ = "0.1.0"` that was always stale
- `empire_core.__version__` now correctly returns the installed version (e.g., `0.3.0`)