### PR TITLE
fix: change library logging from INFO to DEBUG

### DIFF
--- a/src/empire_core/__init__.py
+++ b/src/empire_core/__init__.py
@@ -6,6 +6,7 @@ from importlib.metadata import version
 
 from empire_core.client.client import EmpireClient
 from empire_core.config import EmpireConfig
+from empire_core.pool import AccountPool
 from empire_core.state.models import Alliance, Building, Castle, Player, Resources
 from empire_core.state.unit_models import UNIT_IDS, Army, UnitStats
 from empire_core.state.world_models import MapObject, Movement, MovementResources
@@ -16,6 +17,7 @@ __version__ = version(__package__)
 __all__ = [
     "EmpireClient",
     "EmpireConfig",
+    "AccountPool",
     # Models
     "Player",
     "Castle",

--- a/src/empire_core/accounts.py
+++ b/src/empire_core/accounts.py
@@ -81,7 +81,7 @@ class AccountRegistry:
         self._load_from_env()
 
         self._loaded = True
-        logger.info(f"AccountRegistry loaded {len(self._accounts)} active accounts.")
+        logger.debug(f"AccountRegistry loaded {len(self._accounts)} active accounts.")
 
     def _load_from_file(self, path_str: str):
         """Internal: Load from JSON file."""

--- a/src/empire_core/client/client.py
+++ b/src/empire_core/client/client.py
@@ -146,7 +146,7 @@ class EmpireClient:
         if not self.username or not self.password:
             raise ValueError("Username and password are required")
 
-        logger.info(f"Logging in as {self.username}...")
+        logger.debug(f"Logging in as {self.username}...")
 
         # Connect if not already connected
         if not self.connection.connected:
@@ -214,7 +214,7 @@ class EmpireClient:
             except TimeoutError:
                 logger.warning("gbd packet not received, player state may be incomplete")
 
-            logger.info(f"Logged in as {self.username}")
+            logger.debug(f"Logged in as {self.username}")
             self.is_logged_in = True
             return True
 
@@ -462,16 +462,16 @@ class EmpireClient:
                 main_castle = list(self.state.castles.values())[0]
                 source_x = main_castle.x
                 source_y = main_castle.y
-                logger.info(f"SDI: Using source castle at {source_x}:{source_y}")
+                logger.debug(f"SDI: Using source castle at {source_x}:{source_y}")
             else:
                 logger.warning("SDI: No castles available for source coordinates")
                 return None
 
-        logger.info(f"SDI: Sending request TX={target_x}, TY={target_y}, SX={source_x}, SY={source_y}")
+        logger.debug(f"SDI: Sending request TX={target_x}, TY={target_y}, SX={source_x}, SY={source_y}")
         request = GetSupportDefenseRequest(TX=target_x, TY=target_y, SX=source_x, SY=source_y)
-        logger.info(f"SDI: Request packet = {request.to_packet(zone=self.config.default_zone)}")
+        logger.debug(f"SDI: Request packet = {request.to_packet(zone=self.config.default_zone)}")
         response = self.send(request, wait=wait, timeout=timeout)
-        logger.info(f"SDI: Response = {response}")
+        logger.debug(f"SDI: Response = {response}")
 
         if isinstance(response, GetSupportDefenseResponse):
             return response
@@ -597,7 +597,7 @@ class EmpireClient:
         filter_types = set(item_types) if item_types else None
 
         filter_desc = f"types={list(item_types)}" if item_types else "all types"
-        logger.info(f"Scanning kingdom {kingdom.name} from chunk ({start_cx}, {start_cy}) for {filter_desc}...")
+        logger.debug(f"Scanning kingdom {kingdom.name} from chunk ({start_cx}, {start_cy}) for {filter_desc}...")
 
         def chunk_bounds(cx: int, cy: int) -> tuple[int, int, int, int]:
             """Convert chunk coords to world bounds."""
@@ -706,12 +706,12 @@ class EmpireClient:
             # Log progress periodically
             if total_requests % 50 == 0:
                 elapsed = time.time() - start_time
-                logger.info(
+                logger.debug(
                     f"Scan progress: {total_requests} chunks, {len(collected_items)} items, {elapsed:.1f}s elapsed"
                 )
 
         elapsed = time.time() - start_time
-        logger.info(
+        logger.debug(
             f"Kingdom {kingdom.name} scan complete. "
             f"Scanned {total_requests} chunks in {elapsed:.1f}s, "
             f"found {len(collected_items)} items. "

--- a/src/empire_core/network/connection.py
+++ b/src/empire_core/network/connection.py
@@ -78,7 +78,7 @@ class Connection:
             logger.warning("Already connected")
             return
 
-        logger.info(f"Connecting to {self.url}...")
+        logger.debug(f"Connecting to {self.url}...")
 
         self.ws = websocket.WebSocket()
         self.ws.settimeout(timeout)
@@ -103,7 +103,7 @@ class Connection:
             )
             self._keepalive_thread.start()
 
-            logger.info("Connected successfully")
+            logger.debug("Connected successfully")
 
         except Exception as e:
             logger.error(f"Connection failed: {e}")
@@ -115,7 +115,7 @@ class Connection:
         if not self._running:
             return
 
-        logger.info("Disconnecting...")
+        logger.debug("Disconnecting...")
         self._running = False
 
         # Cancel all waiters
@@ -130,7 +130,7 @@ class Connection:
         if self._keepalive_thread and self._keepalive_thread.is_alive():
             self._keepalive_thread.join(timeout=2.0)
 
-        logger.info("Disconnected")
+        logger.debug("Disconnected")
 
     def _cleanup(self) -> None:
         """Close websocket connection."""

--- a/src/empire_core/pool.py
+++ b/src/empire_core/pool.py
@@ -1,0 +1,215 @@
+"""
+Account pool for managing multiple GGE client connections.
+
+Provides lease/release semantics for account management, automatic cooldown
+handling, and tag-based filtering for different use cases (e.g., tracking,
+scanning, alerts).
+"""
+
+import logging
+from typing import Optional
+
+from empire_core.accounts import Account, accounts
+from empire_core.client.client import EmpireClient
+from empire_core.exceptions import LoginCooldownError
+
+logger = logging.getLogger(__name__)
+
+
+class AccountPool:
+    """
+    Manages a pool of accounts for concurrent GGE operations.
+
+    Allows callers to 'lease' accounts so they aren't used by multiple
+    operations simultaneously. Implements automatic cycling and cooldown handling.
+
+    Usage:
+        pool = AccountPool()
+
+        # Lease any available account
+        client = pool.lease()
+
+        # Lease account with specific tag
+        client = pool.lease(tag="tracking")
+
+        # When done
+        pool.release(client)
+
+    Thread Safety:
+        This class is NOT thread-safe. If using from multiple threads,
+        wrap calls with appropriate locking.
+    """
+
+    def __init__(self):
+        self._busy: set[str] = set()  # Usernames currently in use
+        self._clients: dict[str, EmpireClient] = {}  # Active clients by username
+        self._last_leased_index = -1  # For round-robin cycling
+
+    @property
+    def all_accounts(self) -> list[Account]:
+        """Get all configured accounts."""
+        return accounts.get_all()
+
+    def get_available(self, tag: Optional[str] = None) -> list[Account]:
+        """
+        Get list of available (not busy) accounts.
+
+        Args:
+            tag: Optional tag to filter accounts.
+
+        Returns:
+            List of available accounts, ordered for round-robin cycling.
+        """
+        all_accs = self.all_accounts
+        if not all_accs:
+            return []
+
+        # Round-robin: start from next index after last leased
+        num_accs = len(all_accs)
+        start_idx = (self._last_leased_index + 1) % num_accs
+        cycled_indices = [(start_idx + i) % num_accs for i in range(num_accs)]
+
+        available = []
+        for idx in cycled_indices:
+            acc = all_accs[idx]
+            if acc.username in self._busy:
+                continue
+            if not acc.active:
+                continue
+            if tag and (not acc.tags or tag not in acc.tags):
+                continue
+            available.append(acc)
+
+        return available
+
+    def lease(
+        self,
+        username: Optional[str] = None,
+        tag: Optional[str] = None,
+        login: bool = True,
+    ) -> Optional[EmpireClient]:
+        """
+        Lease an account from the pool.
+
+        Marks the account as busy and optionally logs in. If a specific account
+        is on cooldown, automatically tries the next available account.
+
+        Args:
+            username: Specific username to lease (optional).
+            tag: Tag to filter accounts (optional).
+            login: Whether to login the client (default True).
+
+        Returns:
+            Connected EmpireClient, or None if no accounts available.
+        """
+        # Build candidate list
+        if username:
+            candidates = [
+                acc for acc in self.all_accounts if acc.username == username and acc.username not in self._busy
+            ]
+        else:
+            candidates = self.get_available(tag)
+
+        if not candidates:
+            logger.warning(f"AccountPool: No available accounts (user={username}, tag={tag})")
+            return None
+
+        # Try each candidate until one succeeds
+        for account in candidates:
+            # Update round-robin index
+            all_accs = self.all_accounts
+            for i, acc in enumerate(all_accs):
+                if acc.username == account.username:
+                    self._last_leased_index = i
+                    break
+
+            # Mark as busy
+            self._busy.add(account.username)
+
+            try:
+                # Create client
+                client = account.get_client()
+
+                if login:
+                    client.login()
+
+                # Cache and return
+                self._clients[account.username] = client
+                logger.info(f"AccountPool: Leased {account.username}")
+                return client
+
+            except LoginCooldownError as e:
+                logger.warning(f"AccountPool: {account.username} on cooldown ({e.cooldown}s), trying next...")
+                self._busy.discard(account.username)
+                try:
+                    client.close()
+                except Exception:
+                    pass
+                continue
+
+            except Exception as e:
+                logger.error(f"AccountPool: Failed to lease {account.username}: {e}")
+                self._busy.discard(account.username)
+                try:
+                    client.close()
+                except Exception:
+                    pass
+                continue
+
+        logger.error("AccountPool: All candidate accounts failed")
+        return None
+
+    def release(self, client: EmpireClient, logout: bool = True) -> None:
+        """
+        Release an account back to the pool.
+
+        Args:
+            client: The client to release.
+            logout: Whether to logout/close the client (default True).
+        """
+        if not client or not client.username:
+            return
+
+        username = client.username
+
+        if logout:
+            try:
+                if client.is_logged_in:
+                    client.close()
+            except Exception as e:
+                logger.error(f"AccountPool: Error closing {username}: {e}")
+
+        # Remove from tracking
+        self._clients.pop(username, None)
+        self._busy.discard(username)
+        logger.info(f"AccountPool: Released {username}")
+
+    def release_all(self, logout: bool = True) -> None:
+        """Release all leased accounts."""
+        # Copy keys to avoid mutation during iteration
+        usernames = list(self._clients.keys())
+        for username in usernames:
+            client = self._clients.get(username)
+            if client:
+                self.release(client, logout=logout)
+
+    def get_client(self, username: str) -> Optional[EmpireClient]:
+        """Get a leased client by username."""
+        return self._clients.get(username)
+
+    @property
+    def busy_count(self) -> int:
+        """Number of currently leased accounts."""
+        return len(self._busy)
+
+    @property
+    def available_count(self) -> int:
+        """Number of available accounts."""
+        return len(self.get_available())
+
+    def __len__(self) -> int:
+        """Total number of configured accounts."""
+        return len(self.all_accounts)
+
+    def __repr__(self) -> str:
+        return f"AccountPool(total={len(self)}, busy={self.busy_count}, available={self.available_count})"

--- a/src/empire_core/protocol/models/search.py
+++ b/src/empire_core/protocol/models/search.py
@@ -79,7 +79,18 @@ class SearchAllianceResponse(BaseResponse):
     @property
     def results(self) -> list[AllianceSearchResult]:
         """Parse and return alliance search results."""
-        return [AllianceSearchResult(raw) for raw in self.L if isinstance(raw, list)]
+        results = []
+        for raw in self.L:
+            if isinstance(raw, list) and len(raw) >= 3 and isinstance(raw[2], list):
+                # Format: [rank, score, [alliance_id, name, member_count, ...]]
+                results.append(AllianceSearchResult(raw[2]))
+            elif isinstance(raw, list) and len(raw) >= 2 and isinstance(raw[1], list):
+                # Format: [score, [alliance_id, name, member_count, ...]]
+                results.append(AllianceSearchResult(raw[1]))
+            elif isinstance(raw, list):
+                # Fallback: direct format [alliance_id, name, member_count, ...]
+                results.append(AllianceSearchResult(raw))
+        return results
 
     @property
     def count(self) -> int:

--- a/src/empire_core/state/manager.py
+++ b/src/empire_core/state/manager.py
@@ -100,7 +100,7 @@ class GameState:
                 if pid not in self.players:
                     self.players[pid] = Player(**gpi)
                 self.local_player = self.players[pid]
-                logger.info(f"Local player: {self.local_player.name} (ID: {pid})")
+                logger.debug(f"Local player: {self.local_player.name} (ID: {pid})")
 
         # XP/Level
         gxp = data.get("gxp", {})
@@ -120,7 +120,7 @@ class GameState:
             try:
                 self.local_player.alliance = Alliance(**gal)
                 self.local_player.AID = gal.get("AID")
-                logger.info(f"Alliance: {self.local_player.alliance.name}")
+                logger.debug(f"Alliance: {self.local_player.alliance.name}")
             except Exception as e:
                 logger.warning(f"Could not parse alliance: {e}")
 
@@ -147,7 +147,7 @@ class GameState:
                             self.castles[area_id] = castle
                             self.local_player.castles[area_id] = castle
 
-            logger.info(f"Parsed {len(self.local_player.castles)} castles")
+            logger.debug(f"Parsed {len(self.local_player.castles)} castles")
 
     def _handle_gam(self, data: Dict[str, Any]) -> None:
         """Handle 'Get Army Movements' response."""

--- a/uv.lock
+++ b/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "empire-core"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Change all library `logger.info()` calls to `logger.debug()` so applications control log verbosity
- Add `AccountPool` export from `__init__`
- Improve alliance search response parsing
- Add error handling for alliance service search