### PR TITLE
fix: reduce keepalive interval to 30s

### DIFF
--- a/src/empire_core/network/connection.py
+++ b/src/empire_core/network/connection.py
@@ -360,7 +360,8 @@ class Connection:
             zone = "EmpireEx_21"
 
         while self._running:
-            time.sleep(60)
+            # Send keepalive every 30s to avoid timeouts (server idle timeout is ~60s)
+            time.sleep(30)
 
             if not self._running:
                 break


### PR DESCRIPTION
Reduces the WebSocket keepalive ping interval from 60s to 30s. This prevents connection timeouts on idle accounts (like the tracker) where the server idle timeout might be strict (e.g. 60s) and minor drift causes disconnects.