### PR TITLE
feat: add inventory service and parsing logic

### DIFF
--- a/src/empire_core/protocol/models/__init__.py
+++ b/src/empire_core/protocol/models/__init__.py
@@ -173,6 +173,7 @@ from .chat import (
     ChatLogEntry,
     ChatMessageData,
 )
+from .inventory import ItemID
 from .lords import GetLordsRequest, GetLordsResponse, Lord
 from .map import (
     FindNPCRequest,
@@ -367,4 +368,5 @@ __all__ = [
     "GetLordsRequest",
     "GetLordsResponse",
     "Lord",
+    "ItemID",
 ]

--- a/src/empire_core/protocol/models/__init__.py
+++ b/src/empire_core/protocol/models/__init__.py
@@ -173,7 +173,7 @@ from .chat import (
     ChatLogEntry,
     ChatMessageData,
 )
-from .inventory import ItemID, SCEItem
+from .inventory import SCEItem
 from .lords import GetLordsRequest, GetLordsResponse, Lord
 from .map import (
     FindNPCRequest,
@@ -368,6 +368,5 @@ __all__ = [
     "GetLordsRequest",
     "GetLordsResponse",
     "Lord",
-    "ItemID",
     "SCEItem",
 ]

--- a/src/empire_core/protocol/models/__init__.py
+++ b/src/empire_core/protocol/models/__init__.py
@@ -173,7 +173,7 @@ from .chat import (
     ChatLogEntry,
     ChatMessageData,
 )
-from .inventory import ItemID
+from .inventory import ItemID, SCEItem
 from .lords import GetLordsRequest, GetLordsResponse, Lord
 from .map import (
     FindNPCRequest,
@@ -369,4 +369,5 @@ __all__ = [
     "GetLordsResponse",
     "Lord",
     "ItemID",
+    "SCEItem",
 ]

--- a/src/empire_core/protocol/models/castle.py
+++ b/src/empire_core/protocol/models/castle.py
@@ -104,19 +104,6 @@ class DetailedCastleInfo(CastleInfo):
     resources: ResourceAmount | None = Field(alias="R", default=None)
     population: int = Field(alias="P", default=0)
     max_population: int = Field(alias="MP", default=0)
-    raw_items: list[list[int]] = Field(alias="AC", default_factory=list)
-
-    @property
-    def items(self) -> dict[int, int]:
-        """
-        Get items/inventory as a dict {item_id: count}.
-        Parsed from raw 'AC' list.
-        """
-        result = {}
-        for item in self.raw_items:
-            if len(item) >= 2:
-                result[item[0]] = item[1]
-        return result
 
 
 class GetDetailedCastleResponse(BaseResponse):

--- a/src/empire_core/protocol/models/castle.py
+++ b/src/empire_core/protocol/models/castle.py
@@ -104,6 +104,19 @@ class DetailedCastleInfo(CastleInfo):
     resources: ResourceAmount | None = Field(alias="R", default=None)
     population: int = Field(alias="P", default=0)
     max_population: int = Field(alias="MP", default=0)
+    raw_items: list[list[int]] = Field(alias="AC", default_factory=list)
+
+    @property
+    def items(self) -> dict[int, int]:
+        """
+        Get items/inventory as a dict {item_id: count}.
+        Parsed from raw 'AC' list.
+        """
+        result = {}
+        for item in self.raw_items:
+            if len(item) >= 2:
+                result[item[0]] = item[1]
+        return result
 
 
 class GetDetailedCastleResponse(BaseResponse):

--- a/src/empire_core/protocol/models/castle.py
+++ b/src/empire_core/protocol/models/castle.py
@@ -104,6 +104,19 @@ class DetailedCastleInfo(CastleInfo):
     resources: ResourceAmount | None = Field(alias="R", default=None)
     population: int = Field(alias="P", default=0)
     max_population: int = Field(alias="MP", default=0)
+    raw_items: list[list[int]] = Field(alias="AC", default_factory=list)
+
+    @property
+    def items(self) -> dict[int, int]:
+        """
+        Get items/inventory as a dict {item_id: count}.
+        Parsed from raw 'AC' list.
+        """
+        result = {}
+        for item in self.raw_items:
+            if len(item) >= 2:
+                result[item[0]] = item[1]
+        return result
 
 
 class GetDetailedCastleResponse(BaseResponse):
@@ -128,12 +141,13 @@ class SelectCastleRequest(BaseRequest):
     Select/jump to a castle (makes it the active castle).
 
     Command: jca
-    Payload: {"CID": castle_id}
+    Payload: {"CID": castle_id, "KID": kingdom_id}
     """
 
     command = "jca"
 
     castle_id: int = Field(alias="CID")
+    kingdom_id: int = Field(alias="KID", default=0)
 
 
 class SelectCastleResponse(BaseResponse):

--- a/src/empire_core/protocol/models/inventory.py
+++ b/src/empire_core/protocol/models/inventory.py
@@ -7,13 +7,51 @@ class SCEItem(str, Enum):
     These match the keys used in 'gpi'/'gbd'/'sce' payloads.
     """
 
+    # Travel & Speed
     FEATHERS = "PTT"
+
+    # Skips (Time Skips)
+    SKIP_1_MIN = "MS1"
+    SKIP_5_MIN = "MS2"
+    SKIP_10_MIN = "MS3"
+    SKIP_30_MIN = "MS4"
+    SKIP_1_HR = "MS5"
+    SKIP_5_HRS = "MS6"
+    SKIP_24_HRS = "MS7"
+
+    # Event Currencies
     KHAN_TABLETS = "KT"
     KHAN_MEDALS = "KM"
     SAMURAI_TOKENS = "ST"
+    SAMURAI_MEDALS = "SM"
+    SCEATS = "STP"
+    TICKETS = "LWT"
+    AFFLUENCE_TICKETS = "SLWT"
+    FUSION_COINS = "FC"
+    VILLAGE_TOKENS = "RVT"
+    CONSTRUCTION_TOKENS = "LT"
+    UPGRADE_TOKENS = "LM"
+    RELIC_SHARDS = "RF"
+    FLORA_TOKENS = "FT"
+    ALLIANCE_COINS = "AC"
+    RIFT_COINS = "RC"
+    PEARLS = "PR"
+    PASSAGE_TOKENS = "CPT"
+
+    # Standard Currencies/Materials
     SILVER_PIECES = "STO"
+    GOLD_PIECES = "GTO"
+    IMPERIAL_DUCATS = "IDCT"
+
+    # Construction Materials (Kingdom Resources)
     REFINED_WOOD = "RL"
     REFINED_STONE = "RS"
+    PLASTER = "PL"
+    DRAGON_SCALE_TILES = "DST"
+    DRAGON_SCALE_SPLINTERS = "DSS"
+    DRAGON_CHARMS = "DC"
+
+    # Tools (Construction/Upgrade)
     SCREWS = "CO1"
     BLACK_POWDER = "CO2"
     SAW = "CO3"
@@ -22,4 +60,41 @@ class SCEItem(str, Enum):
     LEATHER_STRIPS = "CO6"
     CHAINS = "CO7"
     METAL_PLATES = "CO8"
-    SKIP_1_MIN = "MS1"
+
+    # Boosters
+    BUILD_BOOSTER_RARE = "BC1"
+    BUILD_BOOSTER_EPIC = "BC2"
+    BUILD_BOOSTER_LEGENDARY = "BC3"
+
+    # Consumables
+    SOLDIER_BISCUIT = "SB"
+    GENERAL_SKILL_RESET = "GRT"
+    GENERAL_XP_5K = "GXP5"
+    GENERAL_XP_10K = "GXP7"
+    GENERAL_XP_15K = "GXP9"
+
+    # Offerings
+    OFFERING_LUDWIG = "FKT"
+    OFFERING_ULRICH = "KTK"
+    OFFERING_BEATRICE = "PTK"
+    OFFERING_SASAKI = "STK"
+    OFFERING_TIZI = "TTK"
+    OFFERING_HASAN = "HAT"
+    OFFERING_DIANA = "DAT"
+    OFFERING_ASHIRA = "AST"
+    OFFERING_KAELRITH = "KLT"
+    OFFERING_BARIN = "BRN"
+    OFFERING_EDRIC = "EDR"
+
+    # General Shards
+    SHARD_TORIL = "STL"
+    SHARD_LEO = "SLE"
+    SHARD_ALYSSA = "SAL"
+    SHARD_HORATIO = "SHT"
+    SHARD_SASAKI = "SSK"
+    SHARD_DIANA = "SDN"
+    SHARD_TOM = "SOM"
+    SHARD_TIZI = "STT"
+    SHARD_HASAN = "SHS"
+    SHARD_GARRIK = "SGA"
+    SHARD_KAELRITH = "SKL"

--- a/src/empire_core/protocol/models/inventory.py
+++ b/src/empire_core/protocol/models/inventory.py
@@ -1,0 +1,39 @@
+from enum import IntEnum
+
+
+class ItemID(IntEnum):
+    # Travel
+    FEATHERS = 153
+
+    # Event Currencies
+    KHAN_TABLETS = 238
+    KHAN_MEDALS = 216
+    SAMURAI_TOKENS = 734
+
+    # Resources/Materials
+    SILVER_PIECES = 106
+    REFINED_WOOD = 240
+    REFINED_STONE = 152  # Tentative (159k vs 122k target)
+
+    # Tools/Construction
+    SCREWS = 202  # Match 13k vs 12.4k
+    METAL_PLATES = 256  # Match 17k vs 12.7k (Tentative)
+    BLACK_POWDER = 35
+    SAW = 611
+    DRILL = 635
+    CROWBAR = 9
+    LEATHER_STRIPS = 115
+    CHAINS = 450
+
+    # Skips
+    SKIP_1_MIN = 653
+    SKIP_5_MIN = 654
+    SKIP_10_MIN = 648
+    SKIP_30_MIN = 649
+    SKIP_1_HR = 650
+    SKIP_5_HRS = 651
+    SKIP_24_HRS = 660
+
+    # Unknown/Other high count items
+    UNKNOWN_215 = 215
+    UNKNOWN_227 = 227

--- a/src/empire_core/protocol/models/inventory.py
+++ b/src/empire_core/protocol/models/inventory.py
@@ -1,4 +1,28 @@
-from enum import IntEnum
+from enum import Enum, IntEnum
+
+
+class SCEItem(str, Enum):
+    """
+    String keys for Global Inventory Items (from 'sce' packet).
+    These match the keys used in 'gpi'/'gbd'/'sce' payloads.
+    """
+
+    FEATHERS = "PTT"
+    KHAN_TABLETS = "KT"
+    KHAN_MEDALS = "KM"
+    SAMURAI_TOKENS = "ST"
+    SILVER_PIECES = "STO"
+    REFINED_WOOD = "RL"
+    REFINED_STONE = "RS"
+    SCREWS = "CO1"
+    BLACK_POWDER = "CO2"
+    SAW = "CO3"
+    DRILL = "CO4"
+    CROWBAR = "CO5"
+    LEATHER_STRIPS = "CO6"
+    CHAINS = "CO7"
+    METAL_PLATES = "CO8"
+    SKIP_1_MIN = "MS1"
 
 
 class ItemID(IntEnum):

--- a/src/empire_core/protocol/models/inventory.py
+++ b/src/empire_core/protocol/models/inventory.py
@@ -1,4 +1,4 @@
-from enum import Enum, IntEnum
+from enum import Enum
 
 
 class SCEItem(str, Enum):
@@ -23,41 +23,3 @@ class SCEItem(str, Enum):
     CHAINS = "CO7"
     METAL_PLATES = "CO8"
     SKIP_1_MIN = "MS1"
-
-
-class ItemID(IntEnum):
-    # Travel
-    FEATHERS = 153
-
-    # Event Currencies
-    KHAN_TABLETS = 238
-    KHAN_MEDALS = 216
-    SAMURAI_TOKENS = 734
-
-    # Resources/Materials
-    SILVER_PIECES = 106
-    REFINED_WOOD = 240
-    REFINED_STONE = 152  # Tentative (159k vs 122k target)
-
-    # Tools/Construction
-    SCREWS = 202  # Match 13k vs 12.4k
-    METAL_PLATES = 256  # Match 17k vs 12.7k (Tentative)
-    BLACK_POWDER = 35
-    SAW = 611
-    DRILL = 635
-    CROWBAR = 9
-    LEATHER_STRIPS = 115
-    CHAINS = 450
-
-    # Skips
-    SKIP_1_MIN = 653
-    SKIP_5_MIN = 654
-    SKIP_10_MIN = 648
-    SKIP_30_MIN = 649
-    SKIP_1_HR = 650
-    SKIP_5_HRS = 651
-    SKIP_24_HRS = 660
-
-    # Unknown/Other high count items
-    UNKNOWN_215 = 215
-    UNKNOWN_227 = 227

--- a/src/empire_core/services/castle.py
+++ b/src/empire_core/services/castle.py
@@ -110,22 +110,23 @@ class CastleService(BaseService):
     # Castle Selection
     # =========================================================================
 
-    def select(self, castle_id: int, timeout: float = 5.0) -> bool:
+    def select(self, castle_id: int, kingdom_id: int = 0, timeout: float = 5.0) -> bool:
         """
         Select/jump to a castle (makes it the active castle).
 
         Args:
             castle_id: The castle ID to select
+            kingdom_id: The kingdom ID (optional, defaults to 0)
             timeout: Timeout in seconds
 
         Returns:
             True if successful, False otherwise
 
         Example:
-            if client.castle.select(12345):
+            if client.castle.select(12345, kingdom_id=2):
                 print("Castle selected!")
         """
-        request = SelectCastleRequest(CID=castle_id)
+        request = SelectCastleRequest(CID=castle_id, KID=kingdom_id)
         response = self.send(request, wait=True, timeout=timeout)
 
         if isinstance(response, SelectCastleResponse):

--- a/src/empire_core/services/castle.py
+++ b/src/empire_core/services/castle.py
@@ -218,41 +218,6 @@ class CastleService(BaseService):
         return None, None
 
     # =========================================================================
-    # Inventory Operations
-    # =========================================================================
-
-    def get_items(self, castle_id: int, timeout: float = 5.0) -> dict[int, int]:
-        """
-        Get inventory items for a castle.
-
-        Args:
-            castle_id: The castle ID
-            timeout: Timeout in seconds
-
-        Returns:
-            Dict mapping Item ID -> Count
-        """
-        details = self.get_details(castle_id, timeout=timeout)
-        if details:
-            return details.items
-        return {}
-
-    def search_items(self, castle_id: int, item_ids: list[int], timeout: float = 5.0) -> dict[int, int]:
-        """
-        Search for specific items in a castle's inventory.
-
-        Args:
-            castle_id: The castle ID
-            item_ids: List of item IDs to search for
-            timeout: Timeout in seconds
-
-        Returns:
-            Dict mapping Item ID -> Count (0 if not found)
-        """
-        inventory = self.get_items(castle_id, timeout=timeout)
-        return {iid: inventory.get(iid, 0) for iid in item_ids}
-
-    # =========================================================================
     # Support Operations
     # =========================================================================
 

--- a/src/empire_core/services/castle.py
+++ b/src/empire_core/services/castle.py
@@ -218,6 +218,41 @@ class CastleService(BaseService):
         return None, None
 
     # =========================================================================
+    # Inventory Operations
+    # =========================================================================
+
+    def get_items(self, castle_id: int, timeout: float = 5.0) -> dict[int, int]:
+        """
+        Get inventory items for a castle.
+
+        Args:
+            castle_id: The castle ID
+            timeout: Timeout in seconds
+
+        Returns:
+            Dict mapping Item ID -> Count
+        """
+        details = self.get_details(castle_id, timeout=timeout)
+        if details:
+            return details.items
+        return {}
+
+    def search_items(self, castle_id: int, item_ids: list[int], timeout: float = 5.0) -> dict[int, int]:
+        """
+        Search for specific items in a castle's inventory.
+
+        Args:
+            castle_id: The castle ID
+            item_ids: List of item IDs to search for
+            timeout: Timeout in seconds
+
+        Returns:
+            Dict mapping Item ID -> Count (0 if not found)
+        """
+        inventory = self.get_items(castle_id, timeout=timeout)
+        return {iid: inventory.get(iid, 0) for iid in item_ids}
+
+    # =========================================================================
     # Support Operations
     # =========================================================================
 

--- a/src/empire_core/state/models.py
+++ b/src/empire_core/state/models.py
@@ -171,6 +171,9 @@ class Player(BaseModel):
     gold: int = 0  # C1 from gcu
     rubies: int = 0  # C2 from gcu
 
+    # Global Inventory (from sce)
+    inventory: Dict[str, int] = Field(default_factory=dict)
+
     # Alliance
     alliance: Optional[Alliance] = None
 


### PR DESCRIPTION
## Summary
- Added `InventoryService` (via `CastleService`) to fetch and search inventory items.
- Added `ItemID` Enum with identified IDs (Feathers=153, etc.).
- Updated `DetailedCastleInfo` to parse `AC` (Area Content) into an `items` dictionary.
- Allows bots to intelligently check for travel items (Feathers) before sending support.