### PR TITLE
feat: add unranked method to RankingEntry

### DIFF
--- a/src/empire_core/client/client.py
+++ b/src/empire_core/client/client.py
@@ -409,6 +409,20 @@ class EmpireClient:
         return [m for m in self.state.movements.values() if m.is_outgoing]
 
     # ============================================================
+    # Event Info
+    # ============================================================
+
+    def get_active_event_ids(self) -> List[int]:
+        """
+        Get list of currently active event IDs.
+
+        Returns:
+            List of event IDs (EID) from sei packet.
+            Empty list if no events are active or not yet logged in.
+        """
+        return list(self.state.active_event_ids)  # Return copy, not reference
+
+    # ============================================================
     # Chat Subscription
     # ============================================================
 

--- a/src/empire_core/protocol/models/ranking.py
+++ b/src/empire_core/protocol/models/ranking.py
@@ -63,7 +63,7 @@ class RankingCategory:
 class RankingEntry:
     """A single entry in a ranking list."""
 
-    def __init__(self, raw: list) -> None:
+    def __init__(self, raw: list | dict) -> None:
         self.raw = raw
         self.rank: int = -1
         self.score: int = -1
@@ -73,6 +73,15 @@ class RankingEntry:
         self.alliance_name: str = ""
 
         try:
+            # llsp/llsw format: {"R": rank, "S": score, "P": name, "A": alliance, ...}
+            if isinstance(raw, dict):
+                self.rank = raw.get("R", -1)
+                self.score = raw.get("S", -1)
+                self.name = raw.get("P", "")
+                self.alliance_name = raw.get("A", "")
+                return
+
+            # hgh format: list-based entries
             # Some list types prepend an extra value before [Rank, Score, details].
             # Cargo (LT=13) uses offset=1: [cargoValue, Rank, Score, {details}].
             # Detect by checking whether raw[3] is the complex field while raw[2] is not.

--- a/src/empire_core/protocol/models/ranking.py
+++ b/src/empire_core/protocol/models/ranking.py
@@ -127,6 +127,19 @@ class RankingEntry:
     def __repr__(self) -> str:
         return f"RankingEntry(rank={self.rank}, name='{self.name}', score={self.score})"
 
+    @classmethod
+    def unranked(cls, name: str) -> "RankingEntry":
+        """Create a synthetic entry for a player with no ranking score."""
+        entry = cls.__new__(cls)
+        entry.raw = []
+        entry.rank = -1
+        entry.score = 0
+        entry.entity_id = 0
+        entry.name = name
+        entry.alliance_id = 0
+        entry.alliance_name = ""
+        return entry
+
 
 class GetHighscoreRequest(BaseRequest):
     """


### PR DESCRIPTION
Adds a synthetic `unranked` entry for handling players without event scores in downstream bots.