### PR TITLE
feat: add spy protocol models and service

### DIFF
--- a/src/empire_core/client/client.py
+++ b/src/empire_core/client/client.py
@@ -1,6 +1,3 @@
-from __future__ import annotations
-from collections.abc import Callable
-
 """
 EmpireClient for EmpireCore.
 
@@ -8,10 +5,12 @@ Uses a threaded Connection class, designed to work well with Discord.py
 by not competing for the event loop.
 """
 
+from __future__ import annotations
 
 import json
 import logging
 import time
+from collections.abc import Callable
 from typing import TYPE_CHECKING, TypeVar
 
 from empire_core.config import (

--- a/src/empire_core/protocol/models/__init__.py
+++ b/src/empire_core/protocol/models/__init__.py
@@ -87,6 +87,8 @@ from .attack import (
     SkipAttackCooldownResponse,
     SkipDefenseCooldownRequest,
     SkipDefenseCooldownResponse,
+    SpyScreenInfoRequest,
+    SpyScreenInfoResponse,
 )
 from .auth import (
     CheckUsernameAvailableRequest,
@@ -191,6 +193,11 @@ from .map import (
     Movement,
     NPCLocation,
     TargetInfo,
+)
+from .messages import (
+    BattleSpyDataRequest,
+    BattleSpyDataResponse,
+    SystemNotificationEvent,
 )
 from .player import (
     LOCATION_TYPES,
@@ -322,6 +329,8 @@ __all__ = [
     "CreateAttackResponse",
     "SendSpyRequest",
     "SendSpyResponse",
+    "SpyScreenInfoRequest",
+    "SpyScreenInfoResponse",
     "GetPresetsRequest",
     "GetPresetsResponse",
     "AttackPreset",
@@ -329,6 +338,10 @@ __all__ = [
     "SkipAttackCooldownResponse",
     "SkipDefenseCooldownRequest",
     "SkipDefenseCooldownResponse",
+    # Messages
+    "SystemNotificationEvent",
+    "BattleSpyDataRequest",
+    "BattleSpyDataResponse",
     # Building
     "BuildRequest",
     "BuildResponse",

--- a/src/empire_core/protocol/models/attack.py
+++ b/src/empire_core/protocol/models/attack.py
@@ -73,21 +73,31 @@ class SendSpyRequest(BaseRequest):
 
     Command: csm
     Payload: {
-        "CID": source_castle_id,
+        "SID": source_castle_id,
         "TX": target_x,
         "TY": target_y,
-        "TK": target_kingdom,
+        "KID": target_kingdom,
         "SC": spy_count,
+        "ST": spy_type,
+        "SE": precision,
+        "HBW": horses_type,
+        "PTT": pay_to_travel,
+        "SD": sd
     }
     """
 
     command = "csm"
 
-    castle_id: int = Field(alias="CID")
+    castle_id: int = Field(alias="SID")
     target_x: int = Field(alias="TX")
     target_y: int = Field(alias="TY")
-    target_kingdom: int = Field(alias="TK", default=0)
+    target_kingdom: int = Field(alias="KID", default=0)
     spy_count: int = Field(alias="SC", default=1)
+    spy_type: int = Field(alias="ST", default=0)
+    precision: int = Field(alias="SE", default=100)
+    horses_type: int = Field(alias="HBW", default=-1)
+    pay_to_travel: int = Field(alias="PTT", default=0)
+    sd: int = Field(alias="SD", default=0)
 
 
 class SendSpyResponse(BaseResponse):
@@ -101,6 +111,44 @@ class SendSpyResponse(BaseResponse):
 
     movement_id: int = Field(alias="MID", default=0)
     arrival_time: int = Field(alias="AT", default=0)
+    error_code: int = Field(alias="E", default=0)
+
+
+# =============================================================================
+# SSI - Spy Screen Info
+# =============================================================================
+
+
+class SpyScreenInfoRequest(BaseRequest):
+    """
+    Get spy screen info (guard count, available spies).
+
+    Command: ssi
+    Payload: {
+        "TX": target_x,
+        "TY": target_y,
+        "KID": target_kingdom
+    }
+    """
+
+    command = "ssi"
+
+    target_x: int = Field(alias="TX")
+    target_y: int = Field(alias="TY")
+    target_kingdom: int = Field(alias="KID", default=0)
+
+
+class SpyScreenInfoResponse(BaseResponse):
+    """
+    Response to spy screen info.
+
+    Command: ssi
+    """
+
+    command = "ssi"
+
+    available_spies: int = Field(alias="AS", default=0)
+    guard_count: int = Field(alias="GC", default=0)
     error_code: int = Field(alias="E", default=0)
 
 
@@ -216,6 +264,9 @@ __all__ = [
     # CSM - Send Spy
     "SendSpyRequest",
     "SendSpyResponse",
+    # SSI - Spy Screen Info
+    "SpyScreenInfoRequest",
+    "SpyScreenInfoResponse",
     # GAS - Get Presets
     "GetPresetsRequest",
     "GetPresetsResponse",

--- a/src/empire_core/protocol/models/messages.py
+++ b/src/empire_core/protocol/models/messages.py
@@ -1,0 +1,73 @@
+"""
+Message and report protocol models.
+
+Commands:
+- sne: System notification event
+- bsd: Battle/spy data
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from .base import BaseRequest, BaseResponse
+
+# =============================================================================
+# SNE - System Notification Event
+# =============================================================================
+
+
+class SystemNotificationEvent(BaseResponse):
+    """
+    System notification event (pushed by server).
+
+    Command: sne
+    """
+
+    command = "sne"
+
+    messages: list[list[Any]] = Field(alias="MSG", default_factory=list)
+
+
+# =============================================================================
+# BSD - Battle/Spy Data
+# =============================================================================
+
+
+class BattleSpyDataRequest(BaseRequest):
+    """
+    Request battle or spy report data.
+
+    Command: bsd
+    Payload: {
+        "MID": message_id
+    }
+    """
+
+    command = "bsd"
+
+    message_id: int = Field(alias="MID")
+
+
+class BattleSpyDataResponse(BaseResponse):
+    """
+    Response containing battle or spy report data.
+
+    Command: bsd
+    """
+
+    command = "bsd"
+
+    message_id: int = Field(alias="MID", default=0)
+    battle_data: dict[str, Any] = Field(alias="B", default_factory=dict)
+    spy_data: list[Any] = Field(alias="S", default_factory=list)
+    error_code: int = Field(alias="E", default=0)
+
+
+__all__ = [
+    "SystemNotificationEvent",
+    "BattleSpyDataRequest",
+    "BattleSpyDataResponse",
+]

--- a/src/empire_core/services/__init__.py
+++ b/src/empire_core/services/__init__.py
@@ -34,4 +34,5 @@ __all__ = [
     "CastleService",
     "LordsService",
     "RankingService",
+    "SpyService",
 ]

--- a/src/empire_core/services/alliance.py
+++ b/src/empire_core/services/alliance.py
@@ -1,10 +1,3 @@
-
-from __future__ import annotations
-from collections.abc import Callable
-import logging
-
-logger = logging.getLogger(__name__)
-
 """
 Alliance service for EmpireCore.
 
@@ -14,8 +7,10 @@ Provides high-level APIs for:
 - Alliance help (help members, help all, request help)
 """
 
+from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from collections.abc import Callable
 
 from empire_core.protocol.models import (
     AllianceBookmark,
@@ -40,8 +35,7 @@ from empire_core.protocol.models import (
 
 from .base import BaseService, register_service
 
-if TYPE_CHECKING:
-    pass
+logger = logging.getLogger(__name__)
 
 
 @register_service("alliance")

--- a/src/empire_core/services/base.py
+++ b/src/empire_core/services/base.py
@@ -2,8 +2,8 @@
 Base service class and registration decorator.
 """
 from __future__ import annotations
-from collections.abc import Callable
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Type, TypeVar
 
 from empire_core.protocol.models import BaseRequest, BaseResponse, parse_response

--- a/src/empire_core/services/spy.py
+++ b/src/empire_core/services/spy.py
@@ -1,0 +1,105 @@
+"""
+Spy service for high-level espionage operations.
+"""
+
+from typing import Any
+
+from ..protocol.models.attack import SendSpyRequest, SpyScreenInfoRequest, SpyScreenInfoResponse
+from ..protocol.models.base import parse_response
+from ..protocol.models.messages import BattleSpyDataRequest, BattleSpyDataResponse, SystemNotificationEvent
+from .base import BaseService, register_service
+
+
+@register_service("spy")
+class SpyService(BaseService):
+    """Service for managing spy operations."""
+
+    def execute_instant_spy(
+        self,
+        source_castle_id: int,
+        target_x: int,
+        target_y: int,
+        target_kingdom: int = 0,
+        risk_tolerance: int = 50,
+    ) -> dict[str, Any]:
+        """
+        Execute an instant spy mission using feathers.
+
+        Args:
+            target_x: Target X coordinate
+            target_y: Target Y coordinate
+            target_kingdom: Target kingdom ID (default 0 for Green)
+            risk_tolerance: Maximum acceptable risk percentage (0-100)
+
+        Returns:
+            Dictionary containing the spy report data, or error info.
+        """
+        # 1. Get spy screen info
+        ssi_req = SpyScreenInfoRequest(
+            TX=target_x,
+            TY=target_y,
+            KID=target_kingdom,
+        )
+        ssi_resp = self.send(ssi_req, wait=True)
+
+        if not isinstance(ssi_resp, SpyScreenInfoResponse) or ssi_resp.error_code != 0:
+            return {"status": "error", "reason": f"ssi_failed_{getattr(ssi_resp, 'error_code', 'unknown')}"}
+
+        # 2. Calculate risk (simplified for now - just use max spies)
+        # In a real implementation, we'd calculate exact spies needed for risk_tolerance
+        spies_to_send = ssi_resp.available_spies
+        if spies_to_send <= 0:
+            return {"status": "error", "reason": "no_spies_available"}
+
+        # 3. Send the spy mission (instant with feathers)
+        csm_req = SendSpyRequest(
+            SID=source_castle_id,
+            TX=target_x,
+            TY=target_y,
+            KID=target_kingdom,
+            SC=spies_to_send,
+            ST=0,
+            SE=100,
+            HBW=-1,
+            PTT=1,  # Use feathers
+            SD=0,
+        )
+
+        # We need to send the packet manually so we can wait for SNE instead of CSM response
+        # Actually, we can just send it and then wait for SNE
+        packet = csm_req.to_packet(zone=self.zone)
+        self.client.connection.send(packet)
+
+        # 4. Wait for the SNE event to get the message ID
+        try:
+            sne_packet = self.client.connection.wait_for("sne", timeout=10.0)
+            if not sne_packet or not isinstance(sne_packet.payload, dict):
+                return {"status": "error", "reason": "invalid_sne_format"}
+
+            sne_event = parse_response("sne", sne_packet.payload)
+
+            if not isinstance(sne_event, SystemNotificationEvent):
+                return {"status": "error", "reason": "invalid_sne_format"}
+
+            # Extract MID from the first message
+            if not sne_event.messages or not sne_event.messages[0]:
+                return {"status": "error", "reason": "invalid_sne_format"}
+
+            message_id = sne_event.messages[0][0]
+
+            # 5. Request the actual spy report data
+            bsd_req = BattleSpyDataRequest(MID=message_id)
+            bsd_resp = self.send(bsd_req, wait=True)
+
+            if not isinstance(bsd_resp, BattleSpyDataResponse) or bsd_resp.error_code != 0:
+                return {"status": "error", "reason": f"bsd_failed_{getattr(bsd_resp, 'error_code', 'unknown')}"}
+
+            return {
+                "status": "success",
+                "message_id": message_id,
+                "spy_data": bsd_resp.spy_data,
+                "battle_data": bsd_resp.battle_data,
+            }
+
+        except Exception as e:
+            return {"status": "error", "reason": f"sne_timeout_or_error_{str(e)}"}

--- a/uv.lock
+++ b/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "empire-core"
-version = "0.22.1"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Added `SpyScreenInfoRequest` & `SpyScreenInfoResponse` (`ssi`) to fetch guard count and available spies.
- Updated `SendSpyRequest` (`csm`) to include fields for instant spying (`ST`, `SE`, `HBW`, `KID`, `PTT`, `SD`).
- Added `SystemNotificationEvent` (`sne`) to catch the server push event containing the `message_id`.
- Added `BattleSpyDataRequest` & `BattleSpyDataResponse` (`bsd`) to fetch the actual spy report data.
- Created `SpyService` with `execute_instant_spy` method to handle the 4-step synchronous flow.