### PR TITLE
fix/explicit disconnect logs

### DIFF
--- a/src/empire_core/client/client.py
+++ b/src/empire_core/client/client.py
@@ -142,7 +142,7 @@ class EmpireClient:
         """Handle disconnect."""
         self.is_logged_in = False
         self.state.shutdown()
-        logger.warning("Client disconnected")
+        logger.warning(f"Client {self.username} disconnected")
 
     def login(self) -> bool:
         """
@@ -232,7 +232,7 @@ class EmpireClient:
             try:
                 self.connection.wait_for("gbd", timeout=self.config.request_timeout)
             except TimeoutError:
-                logger.warning("gbd packet not received, player state may be incomplete")
+                logger.warning(f"gbd packet not received for {self.username}, player state may be incomplete")
 
             logger.debug(f"Logged in as {self.username}")
             self.is_logged_in = True

--- a/src/empire_core/state/manager.py
+++ b/src/empire_core/state/manager.py
@@ -265,6 +265,7 @@ class GameState:
         # Don't remove movements here - wait for explicit arrival (atv/ata) or recall (mrm)
         # packets so we can properly dispatch callbacks with full movement data
         self._previous_movement_ids = current_ids
+        self._arrived_movement_ids.clear()
 
     def _handle_dcl(self, data: dict[str, Any]) -> None:
         """Handle 'Detailed Castle List' response."""


### PR DESCRIPTION
- **fix: pass XT packet error code to payload before parsing**
- **fix: rename global_rank to is_in_ruins for R flag in AllianceMember**
- **fix: race condition in wait_for dropping packets**
- **feat: upgrade map scanner to return player objects and fix property indices**
- **fix: include username in disconnect and login failure logs**
- **perf: clear arrived movement IDs on each gam update to prevent unbounded growth**
