### PR TITLE
fix: correct GetTargetInfoRequest payload for adi command

### DIFF
--- a/src/empire_core/protocol/models/map.py
+++ b/src/empire_core/protocol/models/map.py
@@ -375,13 +375,17 @@ class GetTargetInfoRequest(BaseRequest):
     Get detailed info about a specific map location/target.
 
     Command: adi
-    Payload: {"X": x, "Y": y, "KID": kingdom_id}
+    Payload: {"SX": source_x, "SY": source_y, "TX": target_x, "TY": target_y, "KID": kingdom_id}
+
+    SX/SY is the attacker's source position, TX/TY is the target position.
     """
 
     command = "adi"
 
-    x: int = Field(alias="X")
-    y: int = Field(alias="Y")
+    source_x: int = Field(alias="SX")
+    source_y: int = Field(alias="SY")
+    target_x: int = Field(alias="TX")
+    target_y: int = Field(alias="TY")
     kingdom: Kingdom = Field(alias="KID", default=Kingdom.GREEN)
 
 


### PR DESCRIPTION
## Summary

Fixes #20

The `GetTargetInfoRequest` model was sending `{"X": x, "Y": y, "KID": kid}` but the `adi` command (`C2SGetAttackDungeonInfosVO`) actually requires:

```json
{"SX": source_x, "SY": source_y, "TX": target_x, "TY": target_y, "KID": kid}
```

The old payload caused a `203 INVALID AREA` error on every call.

## Changes

- Replaced `x`/`y` (aliased `"X"`/`"Y"`) with `source_x`/`source_y` (`"SX"`/`"SY"`) and `target_x`/`target_y` (`"TX"`/`"TY"`)
- Updated docstring to reflect the correct payload format

## Testing

Tested live against the game server targeting the Robber Baron NPC at `(214, 1259)` in the Green Kingdom:

```python
request = GetTargetInfoRequest(SX=632, SY=243, TX=214, TY=1259, KID=Kingdom.GREEN)
response = client.send(request, wait=True)
# → GetTargetInfoResponse with valid garrison/area data (no more 203 error)
```

Response included `gaa`, `gui`, `gli` data confirming the server accepted the corrected payload.