### PR TITLE
fix: serialize WebSocket sends with a threading.Lock

### DIFF
--- a/src/empire_core/network/connection.py
+++ b/src/empire_core/network/connection.py
@@ -51,6 +51,11 @@ class Connection:
         self._recv_thread: threading.Thread | None = None
         self._keepalive_thread: threading.Thread | None = None
 
+        # Serializes writes to the WebSocket — websocket-client's send() is not
+        # thread-safe, so concurrent callers (e.g. two asyncio.to_thread tasks
+        # sharing one account) must not interleave frame writes.
+        self._send_lock = threading.Lock()
+
         # Request/response waiters: cmd_id -> ResponseWaiter
         # These are consumed when matched (one response per waiter)
         self._waiters: dict[str, list[ResponseWaiter]] = {}
@@ -163,14 +168,15 @@ class Connection:
         if data.endswith("\x00"):
             data = data[:-1]
 
-        try:
-            if self.ws is None:
-                raise RuntimeError("Not connected")
-            self.ws.send(data)
-            logger.debug(f"Sent: {data[:100]}...")
-        except Exception as e:
-            logger.error(f"Send failed: {e}")
-            raise
+        with self._send_lock:
+            try:
+                if self.ws is None:
+                    raise RuntimeError("Not connected")
+                self.ws.send(data)
+                logger.debug(f"Sent: {data[:100]}...")
+            except Exception as e:
+                logger.error(f"Send failed: {e}")
+                raise
 
     def send_bytes(self, data: bytes) -> None:
         """Send raw bytes to the server."""


### PR DESCRIPTION
## Summary

- `websocket-client`'s `send()` is not thread-safe; concurrent callers sharing one `EmpireClient` (e.g. alliance tracker + property scanner on the same account via `asyncio.to_thread`) could interleave frame writes and corrupt the stream
- Added `_send_lock = threading.Lock()` to `Connection.__init__` and acquire it inside `send()` before writing to the socket

## Details

Single-threaded callers are completely unaffected — the lock is uncontended and acquired/released with negligible overhead. The keepalive thread already routes through `send()` so it is also correctly serialized.

`send_bytes()` delegates to `send()` and is covered automatically.