### PR TITLE
fix: prevent socket disconnects via dual-layer sliding window rate limiter

### DIFF
--- a/src/empire_core/client/map_scanner.py
+++ b/src/empire_core/client/map_scanner.py
@@ -47,9 +47,8 @@ class MapScanner:
         x1, y1, x2, y2 = self._chunk_bounds(cx, cy)
         request = GetMapAreaRequest(KID=kingdom, AX1=x1, AY1=y1, AX2=x2, AY2=y2)
 
-        waiter = self.client.connection.create_waiter("gaa")
-
         # Send and wait for response
+        waiter = self.client.connection.create_waiter("gaa")
         try:
             self.client.send(request, wait=False)
             response = self.client.connection.wait_for_result("gaa", waiter, timeout=request_timeout)
@@ -65,11 +64,16 @@ class MapScanner:
             try:
                 time.sleep(0.1)  # Wait a bit before retry
                 waiter = self.client.connection.create_waiter("gaa")
-                self.client.send(request, wait=False)
-                response = self.client.connection.wait_for_result("gaa", waiter, timeout=request_timeout)
+                try:
+                    self.client.send(request, wait=False)
+                    response = self.client.connection.wait_for_result("gaa", waiter, timeout=request_timeout)
+                finally:
+                    self.client.connection.cancel_waiter("gaa", waiter)
             except Exception as e2:
                 logger.error(f"Chunk ({cx}, {cy}) failed after retry: {e2}")
                 return False
+        finally:
+            self.client.connection.cancel_waiter("gaa", waiter)
 
         if not isinstance(response.payload, dict):
             return False
@@ -156,9 +160,6 @@ class MapScanner:
             if time.time() - start_time > timeout:
                 logger.warning(f"Kingdom scan timeout after {total_requests} requests")
                 break
-
-            # Add small delay to prevent rate limiting/disconnects
-            time.sleep(0.01)
 
             cx, cy = queue.pop(0)
 

--- a/src/empire_core/network/connection.py
+++ b/src/empire_core/network/connection.py
@@ -6,6 +6,7 @@ Designed to work well with Discord.py by not competing for the event loop.
 """
 
 import logging
+import re
 import threading
 import time
 from collections.abc import Callable
@@ -14,7 +15,9 @@ from dataclasses import dataclass, field
 import websocket
 
 from empire_core.exceptions import TimeoutError
+from empire_core.network.rate_limiter import DualRateLimiter
 from empire_core.protocol.errors import GGEError
+from empire_core.protocol.models.base import DEFAULT_ZONE
 from empire_core.protocol.packet import Packet
 
 logger = logging.getLogger(__name__)
@@ -56,7 +59,6 @@ class Connection:
         # sharing one account) must not interleave frame writes.
         self._send_lock = threading.Lock()
 
-        from empire_core.network.rate_limiter import DualRateLimiter
         self._rate_limiter = DualRateLimiter(global_limit=15, command_limits={"gaa": 5})
 
         # Request/response waiters: cmd_id -> ResponseWaiter
@@ -177,7 +179,6 @@ class Connection:
             if len(parts) > 3:
                 command = parts[3]
         elif "<body action=" in data:
-            import re
             match = re.search(r"action=['\"]([^'\"]+)['\"]", data)
             if match:
                 command = match.group(1)
@@ -386,8 +387,6 @@ class Connection:
         logger.debug("Keepalive loop started")
 
         try:
-            from empire_core.protocol.models.base import DEFAULT_ZONE
-
             zone = DEFAULT_ZONE
         except ImportError:
             zone = "EmpireEx_21"

--- a/src/empire_core/network/connection.py
+++ b/src/empire_core/network/connection.py
@@ -56,6 +56,9 @@ class Connection:
         # sharing one account) must not interleave frame writes.
         self._send_lock = threading.Lock()
 
+        from empire_core.network.rate_limiter import DualRateLimiter
+        self._rate_limiter = DualRateLimiter(global_limit=15, command_limits={"gaa": 5})
+
         # Request/response waiters: cmd_id -> ResponseWaiter
         # These are consumed when matched (one response per waiter)
         self._waiters: dict[str, list[ResponseWaiter]] = {}
@@ -168,6 +171,19 @@ class Connection:
         if data.endswith("\x00"):
             data = data[:-1]
 
+        command = "unknown"
+        if data.startswith("%xt%"):
+            parts = data.split("%")
+            if len(parts) > 3:
+                command = parts[3]
+        elif "<body action=" in data:
+            import re
+            match = re.search(r"action=['\"]([^'\"]+)['\"]", data)
+            if match:
+                command = match.group(1)
+
+        self._rate_limiter.acquire(command)
+
         with self._send_lock:
             try:
                 if self.ws is None:
@@ -209,7 +225,7 @@ class Connection:
                 try:
                     self._waiters[cmd_id].remove(waiter)
                     if not self._waiters[cmd_id]:
-                        del self._waiters[cmd_id]
+                        self._waiters.pop(cmd_id, None)
                 except ValueError:
                     pass
 
@@ -338,7 +354,7 @@ class Connection:
                 if waiters_list:
                     waiter = waiters_list.pop(0)
                     if not waiters_list:
-                        del self._waiters[cmd_id]
+                        self._waiters.pop(cmd_id, None)
 
             # Get subscriber callbacks (copy the list)
             with self._subscribers_lock:

--- a/src/empire_core/network/rate_limiter.py
+++ b/src/empire_core/network/rate_limiter.py
@@ -1,0 +1,69 @@
+"""
+Thread-safe rate limiter for EmpireCore WebSocket requests.
+"""
+
+import logging
+import threading
+import time
+from collections import defaultdict, deque
+
+logger = logging.getLogger(__name__)
+
+
+class DualRateLimiter:
+    """
+    A strictly precise Sliding Window Log rate limiter.
+
+    Maintains a global token limit for all requests, plus specific limits for restricted
+    commands (e.g., 'gaa'). Calculates sleep time cleanly without blocking other threads
+    from queueing their own unrestricted commands.
+    """
+
+    def __init__(self, global_limit: int, command_limits: dict[str, int]):
+        self.global_limit = global_limit
+        self.command_limits = command_limits
+
+        self._lock = threading.Lock()
+        self._global_window: deque[float] = deque()
+        self._command_windows: dict[str, deque[float]] = defaultdict(deque)
+
+    def acquire(self, command: str) -> None:
+        """
+        Block the calling thread until it is safe to send the given command.
+        Uses a Sliding Window Log (rolling 1000ms window).
+        """
+        while True:
+            now = time.monotonic()
+
+            with self._lock:
+                # 1. Clean up expired timestamps (older than 1.0 second)
+                while self._global_window and now - self._global_window[0] >= 1.0:
+                    self._global_window.popleft()
+
+                cmd_window = self._command_windows[command]
+                while cmd_window and now - cmd_window[0] >= 1.0:
+                    cmd_window.popleft()
+
+                wait_time = 0.0
+
+                # 2. Check command-specific limit first
+                cmd_limit = self.command_limits.get(command)
+                if cmd_limit and len(cmd_window) >= cmd_limit:
+                    cmd_wait = 1.0 - (now - cmd_window[0])
+                    wait_time = max(wait_time, cmd_wait)
+
+                # 3. Check global limit
+                if len(self._global_window) >= self.global_limit:
+                    global_wait = 1.0 - (now - self._global_window[0])
+                    wait_time = max(wait_time, global_wait)
+
+                # 4. If limits are respected, consume token and proceed
+                if wait_time <= 0:
+                    self._global_window.append(now)
+                    if cmd_limit:
+                        cmd_window.append(now)
+                    return
+
+            # 5. If limits exceeded, sleep outside the lock
+            # Add a 1ms buffer to prevent aggressive busy-spinning
+            time.sleep(wait_time + 0.001)

--- a/src/empire_core/state/unit_models.py
+++ b/src/empire_core/state/unit_models.py
@@ -2,7 +2,6 @@
 Models for units and armies.
 """
 
-
 from pydantic import BaseModel, ConfigDict, Field
 
 

--- a/src/empire_core/utils/helpers.py
+++ b/src/empire_core/utils/helpers.py
@@ -2,7 +2,6 @@
 Helper functions for common game operations.
 """
 
-
 from empire_core.state.models import Castle, Player
 from empire_core.state.world_models import Movement
 from empire_core.utils.enums import MovementType

--- a/uv.lock
+++ b/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "empire-core"
-version = "0.25.1"
+version = "0.25.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem
The `MapScanner` and `AllianceTracker` were causing the connection to drop by exceeding the server's strict socket rate limits. The tracker would burst ~65 requests at once during member polling, and the scanner would spam `gaa` commands, leading to traffic that exceeded 15 RPS and caused immediate socket closures.

## Solution
Implemented a highly precise, thread-safe `DualRateLimiter` using a Sliding Window Log algorithm natively in the `Connection` layer.

- **Global Limit:** Strictly enforces a 15 requests/second limit across the entire socket.
- **Command Limit:** Enforces a 5 requests/second limit specifically for `gaa` (map scanning).
- **Non-blocking Throttle:** Integrated directly into `Connection.send()`. If a thread hits a limit, it calculates the exact millisecond wait time, releases the internal state lock, and sleeps. This prevents head-of-line blocking—meaning the `AllianceTracker` can still slip unrestricted commands through while the `MapScanner` waits for its 5 RPS slot.
- **Cleanup:** Removed the static delay from the map scanner, letting the rate limiter throttle it at the maximum safe speed automatically.
