### PR TITLE
feat: add GameEvent and get_active_events CDN resolver

### DIFF
--- a/src/empire_core/__init__.py
+++ b/src/empire_core/__init__.py
@@ -11,6 +11,7 @@ from empire_core.state.models import Alliance, Building, Castle, Player, Resourc
 from empire_core.state.unit_models import UNIT_IDS, Army, UnitStats
 from empire_core.state.world_models import MapObject, Movement, MovementResources
 from empire_core.utils.enums import KingdomType, MapObjectType, MovementType
+from empire_core.utils.events import GameEvent
 
 __version__ = version(__package__)
 
@@ -35,4 +36,5 @@ __all__ = [
     "KingdomType",
     # Constants
     "UNIT_IDS",
+    "GameEvent",
 ]

--- a/src/empire_core/client/client.py
+++ b/src/empire_core/client/client.py
@@ -11,7 +11,10 @@ import json
 import logging
 import time
 from collections.abc import Callable
-from typing import TypeVar, cast
+from typing import TYPE_CHECKING, TypeVar, cast
+
+if TYPE_CHECKING:
+    from empire_core.utils.events import GameEvent
 
 from empire_core.config import (
     LOGIN_DEFAULTS,
@@ -415,6 +418,38 @@ class EmpireClient:
             Empty list if no events are active or not yet logged in.
         """
         return list(self.state.active_event_ids)  # Return copy, not reference
+
+    def get_active_events(
+        self,
+        lang: str = "en",
+        force_refresh: bool = False,
+    ) -> "list[GameEvent]":
+        """
+        Get currently active events with human-readable names resolved from the GGS CDN.
+
+        Combines ``get_active_event_ids()`` with a CDN lookup to produce typed
+        ``GameEvent`` objects. CDN data is cached after the first call.
+
+        Args:
+            lang: Language code for display names (default: "en").
+            force_refresh: Force re-fetch of CDN data, bypassing the cache.
+
+        Returns:
+            List of GameEvent objects for currently active events.
+            Empty list if no events are active or CDN fetch fails.
+
+        Example:
+            events = client.get_active_events()
+            event_names = {e.internal_name for e in events}
+
+            if "Nomad" in event_names:
+                # handle nomad event ...
+                pass
+        """
+        from empire_core.utils.events import GameEvent, get_active_events
+
+        event_ids = self.get_active_event_ids()
+        return get_active_events(event_ids, lang=lang, force_refresh=force_refresh)
 
     # ============================================================
     # Chat Subscription

--- a/src/empire_core/client/client.py
+++ b/src/empire_core/client/client.py
@@ -11,10 +11,7 @@ import json
 import logging
 import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeVar, cast
-
-if TYPE_CHECKING:
-    from empire_core.utils.events import GameEvent
+from typing import TypeVar, cast
 
 from empire_core.config import (
     LOGIN_DEFAULTS,
@@ -56,6 +53,8 @@ from empire_core.services import (
 )
 from empire_core.state.manager import GameState
 from empire_core.state.world_models import Movement
+from empire_core.utils.events import GameEvent
+from empire_core.utils.events import get_active_events as _get_active_events
 
 logger = logging.getLogger(__name__)
 
@@ -423,7 +422,7 @@ class EmpireClient:
         self,
         lang: str = "en",
         force_refresh: bool = False,
-    ) -> "list[GameEvent]":
+    ) -> list[GameEvent]:
         """
         Get currently active events with human-readable names resolved from the GGS CDN.
 
@@ -446,10 +445,8 @@ class EmpireClient:
                 # handle nomad event ...
                 pass
         """
-        from empire_core.utils.events import get_active_events
-
         event_ids = self.get_active_event_ids()
-        return get_active_events(event_ids, lang=lang, force_refresh=force_refresh)
+        return _get_active_events(event_ids, lang=lang, force_refresh=force_refresh)
 
     # ============================================================
     # Chat Subscription

--- a/src/empire_core/client/client.py
+++ b/src/empire_core/client/client.py
@@ -446,7 +446,7 @@ class EmpireClient:
                 # handle nomad event ...
                 pass
         """
-        from empire_core.utils.events import GameEvent, get_active_events
+        from empire_core.utils.events import get_active_events
 
         event_ids = self.get_active_event_ids()
         return get_active_events(event_ids, lang=lang, force_refresh=force_refresh)

--- a/src/empire_core/utils/events.py
+++ b/src/empire_core/utils/events.py
@@ -1,0 +1,187 @@
+"""
+Active event resolver - maps live event IDs from the server to human-readable names.
+
+Fetches static metadata from the GGS CDN (same pattern as troops.py) and cross-references
+the event IDs returned by the server's `sei` packet to produce typed GameEvent objects.
+
+Usage:
+    # Get raw IDs from the live server connection
+    event_ids = client.get_active_event_ids()
+
+    # Resolve to named events (fetches CDN data, cached after first call)
+    events = get_active_events(event_ids)
+
+    # Branch on event type
+    event_names = {e.internal_name for e in events}
+    if "Nomad" in event_names:
+        # run nomad tasks ...
+        ...
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+from empire_core.utils.troops import fetch_items_data, get_items_version
+
+logger = logging.getLogger(__name__)
+
+# CDN endpoint for translations
+_LANG_META_URL = "https://langserv.public.ggs-ep.com/12/fr/@metadata"
+_LANG_DATA_URL = "https://langserv.public.ggs-ep.com/12@{version}/{lang}/*"
+
+# Module-level caches
+_cached_events_index: dict[int, dict[str, Any]] | None = None  # event_id -> raw event dict
+_cached_translations: dict[str, str] | None = None
+
+
+@dataclass
+class GameEvent:
+    """A resolved active game event with human-readable names."""
+
+    id: int
+    internal_name: str  # Internal type name, e.g. "Nomad", "AllianceBattleGround"
+    display_name: str  # Localized in-game title, e.g. "Nomad Invasion"
+    description: str  # Developer comment / short description
+
+
+def _fetch_translations(lang: str = "en") -> dict[str, str]:
+    """Fetch the active translation dictionary from the GGS language CDN."""
+    meta_res = requests.get(_LANG_META_URL, timeout=10)
+    meta_res.raise_for_status()
+    version_no = meta_res.json()["@metadata"]["versionNo"]
+
+    lang_url = _LANG_DATA_URL.format(version=version_no, lang=lang)
+    lang_res = requests.get(lang_url, timeout=30)
+    lang_res.raise_for_status()
+    return lang_res.json()
+
+
+def _build_events_index(force_refresh: bool = False) -> dict[int, dict[str, Any]]:
+    """
+    Build and cache an index of event_id -> raw event dict from the GGS CDN.
+
+    Args:
+        force_refresh: Bypass cache and re-fetch from CDN.
+
+    Returns:
+        Dict mapping event ID (int) to the raw event entry from items data.
+    """
+    global _cached_events_index
+
+    if _cached_events_index is not None and not force_refresh:
+        return _cached_events_index
+
+    version = get_items_version()
+    items_data = fetch_items_data(version)
+
+    index: dict[int, dict[str, Any]] = {}
+    for event in items_data.get("events", []):
+        try:
+            event_id = int(event["eventID"])
+            index[event_id] = event
+        except (KeyError, ValueError):
+            continue
+
+    _cached_events_index = index
+    logger.info(f"Built events index with {len(index)} entries from GGS CDN (v{version})")
+    return index
+
+
+def _get_translations(lang: str = "en", force_refresh: bool = False) -> dict[str, str]:
+    """
+    Fetch and cache the GGS translation dictionary.
+
+    Args:
+        lang: Language code (default: "en").
+        force_refresh: Bypass cache and re-fetch from CDN.
+
+    Returns:
+        Dict mapping translation keys to localized strings.
+    """
+    global _cached_translations
+
+    if _cached_translations is not None and not force_refresh:
+        return _cached_translations
+
+    try:
+        translations = _fetch_translations(lang=lang)
+        _cached_translations = translations
+        logger.info(f"Loaded {len(translations)} '{lang}' translations from GGS CDN")
+        return translations
+    except Exception as e:
+        logger.warning(f"Failed to fetch translations, display names will fall back to internal names: {e}")
+        return {}
+
+
+def get_active_events(
+    event_ids: list[int],
+    lang: str = "en",
+    force_refresh: bool = False,
+) -> list[GameEvent]:
+    """
+    Resolve a list of active event IDs to typed GameEvent objects.
+
+    Fetches event metadata and translations from the GGS CDN (results are
+    cached after the first call). Pass the IDs from ``client.get_active_event_ids()``.
+
+    Args:
+        event_ids: List of active event IDs from the server's sei packet.
+        lang: Language code for display names (default: "en").
+        force_refresh: Force re-fetch of CDN data, bypassing the cache.
+
+    Returns:
+        List of GameEvent objects for the given IDs. IDs not found in the
+        CDN data are silently skipped.
+
+    Example:
+        event_ids = client.get_active_event_ids()
+        events = get_active_events(event_ids)
+
+        event_names = {e.internal_name for e in events}
+        if "Nomad" in event_names:
+            # handle nomad event ...
+            pass
+    """
+    if not event_ids:
+        return []
+
+    try:
+        index = _build_events_index(force_refresh=force_refresh)
+        translations = _get_translations(lang=lang, force_refresh=force_refresh)
+    except Exception as e:
+        logger.error(f"Failed to fetch event metadata from CDN: {e}")
+        return []
+
+    results: list[GameEvent] = []
+    for eid in event_ids:
+        raw = index.get(eid)
+        if raw is None:
+            logger.debug(f"Event ID {eid} not found in CDN data, skipping")
+            continue
+
+        internal_name = str(raw.get("eventType") or "Unknown")
+        description = (
+            str(raw.get("comment1", "") or "").strip()
+            or str(raw.get("comment2", "") or "").strip()
+            or ""
+        )
+
+        title_key = f"event_title_{eid}"
+        display_name = translations.get(title_key) or internal_name
+
+        results.append(
+            GameEvent(
+                id=eid,
+                internal_name=internal_name,
+                display_name=display_name,
+                description=description,
+            )
+        )
+
+    return results
+
+
+__all__ = ["GameEvent", "get_active_events"]

--- a/src/empire_core/utils/events.py
+++ b/src/empire_core/utils/events.py
@@ -163,11 +163,7 @@ def get_active_events(
             continue
 
         internal_name = str(raw.get("eventType") or "Unknown")
-        description = (
-            str(raw.get("comment1", "") or "").strip()
-            or str(raw.get("comment2", "") or "").strip()
-            or ""
-        )
+        description = str(raw.get("comment1", "") or "").strip() or str(raw.get("comment2", "") or "").strip() or ""
 
         title_key = f"event_title_{eid}"
         display_name = translations.get(title_key) or internal_name

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,13 @@
+"""Smoke tests to verify the package imports correctly."""
+
+import empire_core
+
+
+def test_package_importable() -> None:
+    assert empire_core is not None
+
+
+def test_game_event_exported() -> None:
+    from empire_core import GameEvent
+
+    assert GameEvent is not None


### PR DESCRIPTION
## Summary

Adds the ability to resolve active event IDs into rich `GameEvent` objects by querying the GGS CDN.

### New: `src/empire_core/utils/events.py`
- `GameEvent` dataclass with `id`, `internal_name`, `display_name`, `description` fields
- `get_active_events(event_ids, lang='en', force_refresh=False) -> list[GameEvent]` — resolves raw EIDs to named events
- CDN data is module-level cached (no repeated network calls)
- Reuses existing `get_items_version()` and `fetch_items_data()` from `utils/troops.py`

### Modified: `src/empire_core/client/client.py`
- Added `get_active_events(lang='en', force_refresh=False) -> list[GameEvent]` convenience method

### Modified: `src/empire_core/__init__.py`
- Exports `GameEvent` in public API / `__all__`

### Usage

```python
# Raw event IDs (from live sei packet, no CDN)
event_ids = client.get_active_event_ids()

# Resolved to named GameEvent objects (CDN cached after first call)
events = client.get_active_events()
event_names = {e.internal_name for e in events}

if 'AllianceNomadInvasion' in event_names:
    # handle nomad
    ...
```