### PR TITLE
feat: expand gdi model with full O fields and typed castle parsing

### DIFF
--- a/src/empire_core/protocol/models/player.py
+++ b/src/empire_core/protocol/models/player.py
@@ -8,9 +8,11 @@ Commands:
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 from pydantic import ConfigDict, Field
 
-from .base import BaseRequest, BaseResponse
+from .base import BasePayload, BaseRequest, BaseResponse
 from .map import Kingdom
 
 # =============================================================================
@@ -24,6 +26,8 @@ LOCATION_TYPES = {
     3: "Capital",
     4: "Outpost",
     7: "Treasure Dungeon",
+    12: "Castle",  # Colored kingdom castle (KID 1-4)
+    15: "Camp",
     22: "Metro",
     26: "Monument",
     28: "Laboratory",
@@ -64,6 +68,88 @@ class LocationCapture(BaseResponse):
 
 
 # =============================================================================
+# Player Castle (gcl parsed)
+# =============================================================================
+
+
+class PlayerCastle(BasePayload):
+    """
+    A castle/location from the gdi response's gcl.C[].AI[] arrays.
+
+    AI array format (confirmed from packet examples):
+    [type, x, y, location_id, owner_id, lvl1, lvl2, lvl3, lvl4, lvl5,
+     name, ?, ?, ?, capturer_id_capital, capturer_id_outpost, kingdom, ...]
+
+    Index reference:
+    - 0:  castle_type (1=Castle, 3=Capital, 4=Outpost, 12=?, 15=Camp, 22=Metro)
+    - 1:  x
+    - 2:  y
+    - 3:  location_id (area_id)
+    - 4:  owner_id
+    - 10: name
+    - 14: capturer_id (Capital/Metro)
+    - 15: capturer_id (Outpost)
+    - 16: kingdom (KID)
+    """
+
+    kingdom: int = 0
+    location_id: int = 0
+    x: int = 0
+    y: int = 0
+    castle_type: int = 0
+    owner_id: int = 0
+    name: str = ""
+    capturer_id: int = -1
+
+    @property
+    def castle_type_name(self) -> str:
+        """Human-readable castle type."""
+        return get_location_type_name(self.castle_type)
+
+    @property
+    def is_being_captured(self) -> bool:
+        """Check if this location is currently being captured."""
+        return self.capturer_id != -1
+
+    @classmethod
+    def from_list(cls, data: list, kingdom: int = 0) -> "PlayerCastle":
+        """Parse from a gcl.C[].AI[] array entry."""
+        if not data or len(data) < 4:
+            return cls(kingdom=kingdom)
+
+        castle_type = data[0] if len(data) > 0 else 0
+        x = data[1] if len(data) > 1 else 0
+        y = data[2] if len(data) > 2 else 0
+        location_id = data[3] if len(data) > 3 else 0
+        owner_id = data[4] if len(data) > 4 else 0
+        name = data[10] if len(data) > 10 else ""
+
+        # Capturer ID position depends on type
+        type_name = get_location_type_name(castle_type)
+        if type_name == "Outpost":
+            capturer_id = data[15] if len(data) > 15 else -1
+        elif type_name in ("Capital", "Metro"):
+            capturer_id = data[14] if len(data) > 14 else -1
+        else:
+            capturer_id = -1
+
+        # Kingdom can also be read from index 16 if present (overrides passed-in kingdom)
+        if len(data) > 16 and isinstance(data[16], int):
+            kingdom = data[16]
+
+        return cls(
+            kingdom=kingdom,
+            location_id=location_id,
+            x=x,
+            y=y,
+            castle_type=castle_type,
+            owner_id=owner_id,
+            name=name,
+            capturer_id=capturer_id,
+        )
+
+
+# =============================================================================
 # Player Owner Info
 # =============================================================================
 
@@ -72,7 +158,32 @@ class PlayerOwnerInfo(BaseResponse):
     """
     Owner info from the gdi response's O object.
 
-    Contains basic player information.
+    Field mapping (confirmed from packet examples):
+    - OID: Player ID
+    - N: Player name
+    - AID: Alliance ID
+    - AN: Alliance name
+    - L: Level
+    - LL: Legendary level
+    - H: Honor (or unknown metric)
+    - AVP: Avatar points
+    - CF: Castle count (main castles)
+    - HF: Total castles including outposts
+    - MP: Might/power points
+    - PRE: Title prefix ID
+    - SUF: Title suffix ID
+    - TOPX: Global ranking (-1 if unranked)
+    - DUM: Dummy/inactive account flag
+    - AR: Alliance rank
+    - SA: Special ability/status
+    - VF: VIP flag
+    - PF: Premium flag
+    - RRD: Resource request date
+    - TI: Title index
+    - RPT: Revenge protection time remaining (seconds) — bird
+    - AP: Castle positions [[kingdom, area_id, x, y, castle_type], ...]
+    - VP: Village positions (usually empty)
+    - E: Emblem configuration
     """
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
@@ -82,6 +193,70 @@ class PlayerOwnerInfo(BaseResponse):
     alliance_id: int = Field(alias="AID", default=0)
     alliance_name: str = Field(alias="AN", default="")
     level: int = Field(alias="L", default=0)
+    legendary_level: int = Field(alias="LL", default=0)
+    h_field: int = Field(alias="H", default=0)
+    avatar_points: int = Field(alias="AVP", default=0)
+    castle_count: int = Field(alias="CF", default=0)
+    total_castles: int = Field(alias="HF", default=0)
+    might: int = Field(alias="MP", default=0)
+    title_prefix: int = Field(alias="PRE", default=0)
+    title_suffix: int = Field(alias="SUF", default=-1)
+    top_ranking: int = Field(alias="TOPX", default=-1)
+    is_dummy: bool = Field(alias="DUM", default=False)
+    alliance_rank: int = Field(alias="AR", default=0)
+    special_ability: int = Field(alias="SA", default=0)
+    vip_flag: int = Field(alias="VF", default=0)
+    premium_flag: int = Field(alias="PF", default=0)
+    resource_request_date: int = Field(alias="RRD", default=0)
+    title_index: int = Field(alias="TI", default=-1)
+    revenge_protection_seconds: int = Field(alias="RPT", default=0)
+    castle_positions: list = Field(alias="AP", default_factory=list)
+    village_positions: list = Field(alias="VP", default_factory=list)
+
+    # Emblem — imported inline to avoid circular import at module level
+    emblem: dict | None = Field(alias="E", default=None)
+
+    @property
+    def honor(self) -> int:
+        """Get player's honor (H field)."""
+        return self.h_field
+
+    @property
+    def castles(self) -> list:
+        """Parse AP castle positions. Returns list of MemberCastle objects."""
+        from .alliance import MemberCastle
+
+        return [MemberCastle.from_list(pos) for pos in self.castle_positions]
+
+    @property
+    def has_bird(self) -> bool:
+        """Check if player has revenge protection (bird) active."""
+        return self.revenge_protection_seconds > 0
+
+    @property
+    def bird_end_time(self) -> datetime | None:
+        """
+        Calculate when bird protection ends.
+
+        Returns:
+            Timezone-aware datetime (UTC) when bird expires, or None if no bird.
+
+        Note:
+            Calculated relative to when gdi data was fetched — use promptly.
+        """
+        if self.revenge_protection_seconds <= 0:
+            return None
+        return datetime.now(timezone.utc) + timedelta(seconds=self.revenge_protection_seconds)
+
+    @property
+    def is_leader(self) -> bool:
+        """Check if player is alliance leader (AR=8)."""
+        return self.alliance_rank == 8
+
+    @property
+    def is_officer(self) -> bool:
+        """Check if player is an officer (AR > 0 and < 8)."""
+        return 0 < self.alliance_rank < 8
 
 
 # =============================================================================
@@ -110,16 +285,21 @@ class GetPlayerInfoResponse(BaseResponse):
 
     Command: gdi
     Response format: {
-        "O": {"OID": ..., "N": ..., "AN": ..., ...},
-        "gcl": {"C": [{"KID": ..., "AI": [{"AI": [...]}]}]}
+        "O": { ...player fields... },
+        "gcl": {"PID": ..., "C": [{"KID": ..., "AI": [{"AI": [...]}]}]}
     }
 
     The gcl.C array contains castle/location info per kingdom.
-    Each location has an AI array where:
-    - Index 0: Location type (1=Castle, 3=Capital, 4=Outpost, 22=Metro)
-    - Index 3: Location ID
-    - Index 14: Capturer ID for Capital/Metro
-    - Index 15: Capturer ID for Outpost
+    Each location AI array:
+    - Index 0:  location type (1=Castle, 3=Capital, 4=Outpost, 15=Camp, 22=Metro)
+    - Index 1:  x
+    - Index 2:  y
+    - Index 3:  location ID
+    - Index 4:  owner player ID
+    - Index 10: name
+    - Index 14: capturer ID (Capital/Metro)
+    - Index 15: capturer ID (Outpost)
+    - Index 16: kingdom ID
     """
 
     command = "gdi"
@@ -149,60 +329,66 @@ class GetPlayerInfoResponse(BaseResponse):
         """Get alliance name from owner info."""
         return self.owner.alliance_name if self.owner else ""
 
+    @property
+    def has_bird(self) -> bool:
+        """Check if player has revenge protection (bird) active."""
+        return self.owner.has_bird if self.owner else False
+
+    @property
+    def bird_end_time(self) -> datetime | None:
+        """When bird protection ends (UTC), or None."""
+        return self.owner.bird_end_time if self.owner else None
+
+    def get_castles(self) -> list[PlayerCastle]:
+        """
+        Parse gcl.C into a flat list of PlayerCastle objects.
+
+        Returns:
+            All castles/outposts/locations across all kingdoms.
+        """
+        castles = []
+        worlds = self.raw_castle_list.get("C", [])
+
+        for world in worlds:
+            kingdom = world.get("KID", 0)
+            locations = world.get("AI", [])
+
+            for loc_wrapper in locations:
+                location = loc_wrapper.get("AI", []) if isinstance(loc_wrapper, dict) else []
+                if not location:
+                    continue
+                # Handle nested list (e.g. [[10, 127, ...]])
+                if location and isinstance(location[0], list):
+                    location = location[0]
+                castles.append(PlayerCastle.from_list(location, kingdom=kingdom))
+
+        return castles
+
     def get_location_captures(self) -> list[LocationCapture]:
         """
         Extract locations that are being captured.
 
-        Parses the gcl.C array to find locations with active captures.
-
         Returns:
-            List of LocationCapture objects for locations being captured.
+            List of LocationCapture objects for locations with active captures.
         """
         captures = []
-        worlds = self.raw_castle_list.get("C", [])
-
-        for world in worlds:
-            try:
-                kingdom = Kingdom(world.get("KID", 0))
-            except ValueError:
-                # Skip unknown kingdoms
-                continue
-
-            locations = world.get("AI", [])
-
-            for loc_wrapper in locations:
-                # Each location is wrapped: {"AI": [type, ?, ?, loc_id, ...]}
-                location = loc_wrapper.get("AI", []) if isinstance(loc_wrapper, dict) else []
-                if not location or len(location) < 4:
+        for castle in self.get_castles():
+            if castle.is_being_captured:
+                try:
+                    kingdom = Kingdom(castle.kingdom)
+                except ValueError:
                     continue
-
-                loc_type = location[0]
-                loc_type_name = get_location_type_name(loc_type)
-
-                # Only process capturable location types
-                if loc_type_name not in ("Outpost", "Capital", "Metro"):
-                    continue
-
-                loc_id = location[3]
-
-                # Capturer ID position depends on location type
-                if loc_type_name == "Outpost":
-                    capturer_id = location[15] if len(location) > 15 else -1
-                else:  # Capital or Metro
-                    capturer_id = location[14] if len(location) > 14 else -1
-
-                # Only include if being captured
-                if capturer_id != -1:
-                    captures.append(
-                        LocationCapture(
-                            location_id=loc_id,
-                            location_type=loc_type,
-                            location_type_name=loc_type_name,
-                            kingdom=kingdom,
-                            capturer_id=capturer_id,
-                        )
+                captures.append(
+                    LocationCapture(
+                        location_id=castle.location_id,
+                        location_type=castle.castle_type,
+                        location_type_name=castle.castle_type_name,
+                        x=castle.x,
+                        y=castle.y,
+                        kingdom=kingdom,
+                        capturer_id=castle.capturer_id,
                     )
-
+                )
         return captures
 
     def get_all_captures_by_location(self) -> dict[int, int]:
@@ -219,6 +405,7 @@ __all__ = [
     "GetPlayerInfoRequest",
     "GetPlayerInfoResponse",
     "PlayerOwnerInfo",
+    "PlayerCastle",
     "LocationCapture",
     "LOCATION_TYPES",
     "get_location_type_name",


### PR DESCRIPTION
## Summary

Expands `PlayerOwnerInfo` and `GetPlayerInfoResponse` with all confirmed fields from the GGE `gdi` packet's `O` object.

## Changes

### `PlayerOwnerInfo` — new typed fields
- `revenge_protection_seconds` (RPT) — bird/peace duration in seconds
- `castle_positions` (AP) — raw castle position list
- `legendary_level` (LL), `h_field` (H), `avatar_points` (AVP)
- `castle_count` (CF), `total_castles` (HF), `might` (MP)
- `title_prefix` (PRE), `title_suffix` (SUF), `top_ranking` (TOPX)
- `is_dummy` (DUM), `alliance_rank` (AR), `special_ability` (SA)
- `vip_flag` (VF), `premium_flag` (PF), `resource_request_date` (RRD)
- `title_index` (TI), `emblem` (E), `village_positions` (VP)

### `PlayerOwnerInfo` — new properties
- `has_bird` / `bird_end_time` — revenge protection status
- `castles` — parsed `MemberCastle` list from AP field
- `is_leader` / `is_officer` / `honor`

### New `PlayerCastle` model
- Typed parsing of `gcl.C[]` array entries via `from_list(data, kingdom)`

### `GetPlayerInfoResponse` additions
- `get_castles() -> list[PlayerCastle]`
- `has_bird` / `bird_end_time` properties
- `get_location_captures()` refactored to use `get_castles()` internally

### LOCATION_TYPES
- Added type 12 as "Castle" (colored kingdom castle, KID 1–4)

## Testing
- Existing tests pass (`uv run pytest`)
- Manually verified against live `gdi` packet data